### PR TITLE
Support for empty assets property in old qsets

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "version": "1.1.5",
   "dependencies": {
-    "materia-widget-development-kit": "2.5.0"
+    "materia-widget-development-kit": "2.5.1"
   },
   "devDependencies": {
     "angular-mocks": "~1.5.0",

--- a/src/controllers/player.coffee
+++ b/src/controllers/player.coffee
@@ -68,7 +68,7 @@ Matching.controller 'matchingPlayerCtrl', ['$scope', '$timeout', '$sce', ($scope
 				_pageIndex++
 
 			wrapQuestionUrl = ->
-				if item.assets and item.assets[0] != 0 and item.assets[0] != undefined # for qsets published after this commit, this value will be 0, for older qsets it's undefined
+				if Array.isArray(item.assets) and item.assets[0] != 0 and item.assets[0] != undefined # for qsets published after this commit, this value will be 0, for older qsets it's undefined
 					return $sce.trustAsResourceUrl Materia.Engine.getImageAssetUrl(item.assets[0])
 
 			$scope.pages[_pageIndex].questions.push {
@@ -91,14 +91,14 @@ Matching.controller 'matchingPlayerCtrl', ['$scope', '$timeout', '$sce', ($scope
 			}
 
 			# Adjust if this is a 'fakeout' answer option
-			if item.assets[1] == 0 and not item.answers[0].text.length
+			if Array.isArray(item.assets) and item.assets[1] == 0 and not item.answers[0].text.length
 				_itemIndex++
 				_indexShift++
 				$scope.totalItems--
 				continue
 
 			wrapAnswerUrl = ->
-				if item.assets[1] != 0 and item.assets[1] != undefined # for qsets published after this commit, this value will be 0, for older qsets it's undefined
+				if Array.isArray(item.assets) and item.assets[1] != 0 and item.assets[1] != undefined # for qsets published after this commit, this value will be 0, for older qsets it's undefined
 					return $sce.trustAsResourceUrl Materia.Engine.getImageAssetUrl(item.assets[1])
 
 			$scope.pages[_pageIndex].answers.push {

--- a/src/controllers/player.coffee
+++ b/src/controllers/player.coffee
@@ -68,7 +68,7 @@ Matching.controller 'matchingPlayerCtrl', ['$scope', '$timeout', '$sce', ($scope
 				_pageIndex++
 
 			wrapQuestionUrl = ->
-				if item.assets[0] != 0 and item.assets[0] != undefined # for qsets published after this commit, this value will be 0, for older qsets it's undefined
+				if item.assets and item.assets[0] != 0 and item.assets[0] != undefined # for qsets published after this commit, this value will be 0, for older qsets it's undefined
 					return $sce.trustAsResourceUrl Materia.Engine.getImageAssetUrl(item.assets[0])
 
 			$scope.pages[_pageIndex].questions.push {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4993,10 +4993,10 @@ materia-server-client-assets@2.1.0:
     js-snakecase "^1.2.0"
     ngmodal ucfcdl/ngModal#v1.2.2
 
-materia-widget-development-kit@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/materia-widget-development-kit/-/materia-widget-development-kit-2.5.0.tgz#0cc4d82854abf21286c18367cbede374529385b6"
-  integrity sha512-nvYBA/ZBm4SXpLWo6cccm0EDplmBAkcY4c9mjWCuY2BUwJvBgxvA33cKscYg0ktmI3dolPCYMXnb5CERx4239g==
+materia-widget-development-kit@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/materia-widget-development-kit/-/materia-widget-development-kit-2.5.1.tgz#32b8601f62bbfdf94e29f3665867dc39d058ba82"
+  integrity sha512-evxKn89VvmoW2cFMbn9+PlLCLioJG9urcUIXGYZ/krKX9yib/zWrRDiUMal7G2OU9tCj4AZdJcx3rHLdTrwW6A==
   dependencies:
     "@babel/core" "^7.4.5"
     "@babel/preset-env" "^7.4.5"
@@ -5372,7 +5372,7 @@ next-tick@^1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-"ngmodal@github:ucfcdl/ngModal#v1.2.2":
+ngmodal@ucfcdl/ngModal#v1.2.2:
   version "1.2.2"
   resolved "https://codeload.github.com/ucfcdl/ngModal/tar.gz/6abad982bdb8f258ffcdc20316a907c2292399d2"
 


### PR DESCRIPTION
To test:
1. Make a new Matching widget, or grab the widget ID of an existing one, on your local Materia instance
2. grab the qset from the selected widget out of the DB, base64 decode it, and locate an `assets: [ ... ]` property
3. change the property to `assets: null`, base64 re-encode the qset, and re-enter into the database under the most recent qset for that widget ID
4. play or preview the widget. Earlier versions of Matching will choke on the null asset property. The hotfix allows the widget to load correctly.