### PR TITLE
Enables AI question generation

### DIFF
--- a/src/controllers/creator.coffee
+++ b/src/controllers/creator.coffee
@@ -52,9 +52,9 @@ angular.module 'matching', ['ngAnimate']
 			for item in _items
 				$scope.addWordPair(item.questions[0].text, item.answers[0].text, _checkAssets(item), item.id)
 
-	materiaCallbacks.onSaveClicked = ->
+	materiaCallbacks.onSaveClicked = (mode) ->
 		# don't allow empty sets to be saved.
-		if _buildSaveData()
+		if _buildSaveData() or mode is 'history'
 			Materia.CreatorCore.save $scope.widget.title, _qset
 		else
 			$scope.showErrorDialog = true

--- a/src/install.yaml
+++ b/src/install.yaml
@@ -10,6 +10,7 @@ general:
   is_qset_encrypted: Yes
   is_answer_encrypted: Yes
   is_storage_enabled: No
+  is_generable: True
   api_version: 2
 files:
   creator: creator.html
@@ -39,3 +40,8 @@ meta_data:
     or definition.
   accessibility_keyboard: Full
   accessibility_reader: Full
+  generation_prompt: >
+    Each item in the inner items array represents a matching pair. The text in the questions property represents one half of the pair,
+    and the text in the answers property represents the other half. Every item representing a matched pair contains an assets property,
+    which should always contain an array with 3 index positions: the first two should always be the integer 0, and the third should be a string
+    containing a random integer. 


### PR DESCRIPTION
Relies on https://github.com/ucfopen/Materia/pull/1582, or Materia `dev/10.3.0` or `v10.3.0` (whenever the PR is merged)

Adds the following:
- `is_generable` property to `install.yaml`
- `generation_prompt` metadata property to `install.yaml`
- `onSaveClicked` validation pass-through when `mode` is `'history'`
 