### PR TITLE
Updated score module to handle duplicate left-hand duplicate terms

### DIFF
--- a/src/controllers/creator.coffee
+++ b/src/controllers/creator.coffee
@@ -128,13 +128,19 @@ angular.module 'matching', ['ngAnimate']
 		assets
 
 	_buildSaveData = ->
+		
+		# validate question bank value in case the word pair count has changed since the dialog was last opened
+		if $scope.questionBankVal > $scope.widget.wordPairs.length then $scope.questionBankVal = $scope.questionBankValTemp = $scope.widget.wordPairs.length
+
 		_qset.items = []
-		_qset.options = {enableQuestionBank: $scope.enableQuestionBank, questionBankVal: $scope.questionBankVal}
 		_qset.items[0] =
 			name: "null"
 			items: []
+		_qset.options =
+			enableQuestionBank: $scope.enableQuestionBank
+			questionBankVal: $scope.questionBankVal
+	
 		wordPairs = $scope.widget.wordPairs
-
 		return false if not wordPairs.length
 
 		toRemove = []


### PR DESCRIPTION
Resolves #53 

- Moves string comparison prep into an instance function
- For every log item, the question text (left side of pair) is compared against all other questions for duplicates. Answer text matches associated with duplicates are also considered valid, and are added to an array of possible answers. The log's answer text is now compared against all possible answers for a given log, which should now accommodate duplicate answer text (via `$givenAnswer`) and duplicate question text (via matches with `$possibleAnswers`).

Last second, unrelated fix:
- Adds validation to question bank value on save to ensure it's not set higher than the current word pair count.