### PR TITLE
Added safeguarding for question bank value on word pair deletion

### DIFF
--- a/src/controllers/creator.coffee
+++ b/src/controllers/creator.coffee
@@ -29,7 +29,12 @@ angular.module 'matching', ['ngAnimate']
 	$scope.addWordPair = (q=null, a=null, media=[0,0], id='') ->
 		$scope.widget.wordPairs.push {question:q, answer:a, media:media, id:id}
 
-	$scope.removeWordPair = (index) -> $scope.widget.wordPairs.splice(index, 1)
+	$scope.removeWordPair = (index) ->
+		# Update question bank value if it's out of bounds once the word pair is removed
+		if($scope.questionBankVal > $scope.widget.wordPairs.length)
+			$scope.questionBankVal = $scope.questionBankValTemp = $scope.widget.wordPairs.length
+
+		$scope.widget.wordPairs.splice(index, 1)
 
 	$scope.removeAudio = (index, which) -> $scope.widget.wordPairs[index].media.splice(which, 1, 0)
 


### PR DESCRIPTION
Basically just added a check on word pair deletion, to update the question bank value if it's higher than that of the word pair count. This way, the player won't encounter a weird error using invalid question bank data. 

Fixes #55 .